### PR TITLE
refactor: separate optimizer, scheduler from train.py

### DIFF
--- a/code/optimizer.py
+++ b/code/optimizer.py
@@ -1,0 +1,4 @@
+import torch
+
+def optim(args, trainable_params):
+    return getattr(torch.optim, args.optimizer)(trainable_params, lr=args.learning_rate)

--- a/code/scheduler.py
+++ b/code/scheduler.py
@@ -1,0 +1,8 @@
+from torch.optim import lr_scheduler
+
+def sched(args, optimizer):
+    if args.scheduler == "multistep":
+        return lr_scheduler.MultiStepLR(optimizer, milestones=[args.max_epoch // 2, args.max_epoch // 2 * 2], gamma=0.1)
+    elif args.scheduler == "cosine":
+        return lr_scheduler.CosineAnnealingLR(optimizer, T_max=args.max_epoch, eta_min=0)
+      


### PR DESCRIPTION
## Overview
- optimizer와 scheduler 따로 관리할 수 있도록 파일 분리

## Change Log
- optimizer.py, scheduler.py 생성

## To Reviewer
- optimizer의 경우 주로 변경되는 파라미터가 learning rate 밖에 없다고 생각하여 getattr함수로 구현하였기 때문에,
optimizer 함수 이름을 torch.optim의 이름에 맞춰(대소문자 확인 필요) 지정해줘야 합니다.
- scheduler는 함수마다 지정해주는 파라미터 종류가 많아 조건문 형태로 구현하였습니다.

## Issue Tags
- Closed: #21 