### PR TITLE
feat: training after converting from ufo to coco 

### DIFF
--- a/tools/coco_to_ufo.py
+++ b/tools/coco_to_ufo.py
@@ -1,0 +1,60 @@
+from typing import Dict
+import json
+import datetime
+
+def coco_to_ufo(file: Dict, output_path: str) -> None:
+    for annotation in file['annotations']:
+        file_info = file['images'][int(annotation['image_id'])-1]
+        image_name = file_info['file_name']
+        if image_name not in ufo['images']:
+            ufo['images'][image_name] = {
+                "paragraphs": {},
+                "words": {},
+                "chars": {},
+                "img_w": file_info["width"],
+                "img_h": file_info["height"],
+                "tags": ["re-annotated"],
+                "relations": {},
+                "annotation_log": {
+                    "worker": "",
+                    "timestamp": now,
+                    "tool_version": "LabelMe or CVAT",
+                    "source": None
+                    },
+                "license_tag": {
+                    "usability": True,
+                    "public": False,
+                    "commercial": True,
+                    "type": None,
+                    "holder": "Upstage"
+                    }
+                }
+            anno_id = 1
+        ufo['images'][image_name]['words'][str(anno_id).zfill(4)] = {
+            "transcription": "",
+            "points": [annotation['segmentation'][0][i:i+2] for i in range(0, len(annotation['segmentation'][0]), 2)],
+            "orientation": "Horizontal",
+            "language": None,
+            "tags": None,
+            "confidence": None,
+            "illegibility": False
+        }
+        anno_id += 1
+
+    with open(output_path, "w") as f:
+        json.dump(ufo, f, indent=4)
+
+
+now = datetime.datetime.now()
+now = now.strftime('%Y-%m-%d %H:%M:%S')
+
+input_path = '../data/medical/ufo/train_coco.json'
+output_path = '../data/medical/ufo/train_a.json'
+
+ufo = {
+    'images': {}
+}
+
+with open(input_path, 'r') as f:
+    file = json.load(f)
+coco_to_ufo(file, output_path)

--- a/tools/ufo_to_coco.py
+++ b/tools/ufo_to_coco.py
@@ -1,0 +1,81 @@
+from typing import Dict
+import json
+import datetime
+
+def ufo_to_coco(file: Dict, output_path: str) -> None:
+    img_id = 1 #COCO는 1부터 시작
+    annotation_id = 1 #COCO는 1부터 시작
+    images = []
+    annotations = []
+    for fname, data in file.items():
+        image = {
+            "id": img_id,
+            "width": data['img_w'],
+            "height": data['img_h'],
+            "file_name": fname,
+            "license": 1,
+            "flickr_url": None,
+            "coco_url": None,
+            "date_captured": now
+        }
+        images.append(image)
+        for anno_id, annotation in data['words'].items():
+            if annotation['illegibility'] == True:
+                continue
+            min_x = min(item[0] for item in annotation['points'])
+            min_y = min(item[1] for item in annotation['points'])
+            max_x = max(item[0] for item in annotation['points'])
+            max_y = max(item[1] for item in annotation['points'])
+            width = max_x - min_x
+            height = max_y - min_y
+            coco_annotation = {
+                "id": annotation_id,
+                "image_id": img_id,
+                "category_id": 1,
+                "segmentation": [[value for sublist in annotation['points'] for value in sublist]],
+                "area": width * height,
+                "bbox": [min_x, min_y, width, height],
+                "iscrowd": 0
+            }
+            annotations.append(coco_annotation)
+            annotation_id += 1
+        img_id += 1
+        
+    coco = {
+        'info' : info,
+        'images' : images,
+        'annotations' : annotations,
+        'licenses' : licenses,
+        'categories' : categories
+    }
+    with open(output_path, 'w') as f:
+        json.dump(coco, f, indent=4)
+
+
+now = datetime.datetime.now()
+now = now.strftime('%Y-%m-%d %H:%M:%S')
+
+input_path = '/data/ephemeral/home/level2-cv-datacentric-cv-01/data/medical/ufo/valid_split.json'
+output_path = '/data/ephemeral/home/level2-cv-datacentric-cv-01/data/medical/ufo/valid_split_coco.json'
+
+info = {
+    'year': 2024,
+    'version': '1.0',
+    'description': 'OCR Competition Data',
+    'contributor': 'Naver Boostcamp',
+    'url': 'https://aistages-api-public-prod.s3.amazonaws.com/app/Competitions/000273/data/data.tar.gz',
+    'date_created': now
+}
+licenses = {
+    'id': '1',
+    'name': 'For Naver Boostcamp Competition',
+    'url': None
+}
+categories = [{
+    'id': 1,
+    'name': 'word'
+}]
+
+with open(input_path, 'r') as f:
+    file = json.load(f)
+ufo_to_coco(file['images'], output_path)


### PR DESCRIPTION
## Overview
- numpy로 직접 구현된 transform 연산들을 albumentation으로 바꾸면 학습 속도 향상에 효과를 보이지 않을까 하여 시도
- epoch 시작 시 멈춰있는 양상에 변화 없음

## Change Log
- tools/ufo_to_coco.py를 통해 포맷 변환 후 train_split.json 을 coco 로 변환
- transform 함수들을 albumentation 로 바꿔준 COCOSceneTextDataset 정의
- coco format 의 변수명과 구조에 맞게 train.py 코드 수정

## To Reviewer
- transform numpy 연산들보다 map을 생성하는 부분에서 처리량이 많아지는 것이라 추측하고, 이 경우 coco format 변환이 영향을 못 미칠 것
- OCR task는 map을 만들어주는 것이 필수인데, 그러면 학습 속도 개선은 pickle 파일 변환만이 답인 것일까

## Issue Tags
- Closed: #24 